### PR TITLE
chefkoch.de

### DIFF
--- a/list/3-rules.txt
+++ b/list/3-rules.txt
@@ -776,3 +776,5 @@ redtube.com##div[class][style]:has(> div[class][style] > a.removeAdLink)
 ! === blockads.fivefilters.org
 ||blockads.fivefilters.org$inline-script
 blockads.fivefilters.org###no-blocking:style(display: block !important;)
+||www.chefkoch.de/ck.de/*$image
+||www.chefkoch.de/ck.de/*$subdocument


### PR DESCRIPTION
This will effectively kill chefkoch.de's way of getting arround adblockers.
I thought it might be usefull as [https://chefkoch.de](https://chefkoch.de) currently gets arround many adblockers, but
this simple rule blocks that operation.

### Explain why is this change needed (required):

Currently [https://chefkoch.de](https://chefkoch.de) bypasses nano defender completely.

### Test link (if applicable):

[https://chefkoch.de](https://chefkoch.de)

### Screenshots and reproduction steps (if applicable):

Visit [https://chefkoch.de](https://chefkoch.de) with enabled nano defender.

### Add everything else that you believe to be useful below (optional):

I tested the new filters and they work great at first sight, however, I am not 1000% sure they won't break anything.
