### PR TITLE
ani.gamer.com.tw

### DIFF
--- a/list/2-integration.txt
+++ b/list/2-integration.txt
@@ -30,6 +30,9 @@
 # https://github.com/NanoMeow/QuickReports/issues/528
 # https://github.com/uBlockOrigin/uAssets/issues/4293
 @@||vd.l.qq.com/proxyhttp$xhr,domain=sports.qq.com|v.qq.com
+# https://github.com/uBlockOrigin/uAssets/4290
+ani.gamer.com.tw##+js(nano-setInterval-booster.js,,,0.02)
+ani.gamer.com.tw##+js(nano-setTimeout-booster.js,,,0.02)
 
 # ---------------------------------------------------------------------------- #
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -54,7 +54,7 @@
     "webRequest",
     "webRequestBlocking"
   ],
-  "version": "15.0.0.102",
+  "version": "15.0.0.103",
   "web_accessible_resources": [
     "resources/*"
   ]


### PR DESCRIPTION
### Explain why is this change needed (required):
The timer boost is required for integrate with ND for skip ads (Ads not skipped without integrated with ND, they use client side timer to verify whether ad is end). Note that again I only have solution for Firefox.

Also bump version if this fix publish.

### Test link (if applicable):
https://ani.gamer.com.tw/animeVideo.php?sn=11335
(Geo lock, reporter can provide VPN)

### Screenshots and reproduction steps (if applicable):
1. Connect VPN (if required)
2. add the two timer boost (just as this PR)
3. Use the pre-release ND on Firefox (on my page)
4. Ads should skip automatically after several second instead of 30 (and ads are muted and hidden)

### Issues that are related (if applicable):
[See my related commit](https://github.com/LiCybora/NanoDefenderFirefox/commit/ac13d482272ae416e5514c9a59c5a28dcc88accb)

### Add everything else that you believe to be useful below (optional):
To ensure version number sync, maybe I make pull request here so that you can know I bump the version?
