### PR TITLE
cheatsquad.gg

### DIFF
--- a/list/3-rules.txt
+++ b/list/3-rules.txt
@@ -736,5 +736,11 @@ redtube.com##div[class][style]:has(> div[class][style] > a.removeAdLink)
 ! === blockads.fivefilters.org
 ||blockads.fivefilters.org$inline-script
 blockads.fivefilters.org###no-blocking:style(display: block !important;)
+! === cheatsquad.gg
+@@||cheatsquad.gg/js/ads.js$script
+cheatsquad.gg#@#.adsbygoogle
+cheatsquad.gg#@#.ad_skyscraper
+cheatsquad.gg#@#.ad_leaderboard
+cheatsquad.gg#@#+js(acis, document.getElementById, ad)
 
 # ------------------------------------------------------------------------------------------------------------------- #


### PR DESCRIPTION

### Explain why is this change needed (required):
Prevent cheatsquad.gg from detecting adblock


### Test link (if applicable):
https://cheatsquad.gg/cheat/ioHDbW

### Screenshots and reproduction steps (if applicable):
Visit cheatsquad.gg with nano defenders enabled
Press any category
Press a download button
![Cattura](https://user-images.githubusercontent.com/44278678/73893480-11333500-487a-11ea-96bf-aa687a7e3bbc.PNG)


### Issues that are related (if applicable):


### Add everything else that you believe to be useful below (optional):
Probably this solution isn't pretty but it is working
